### PR TITLE
Fixed clrDir() to use shutil.rmtree() for proper directory handling

### DIFF
--- a/src/auto-ocd.py
+++ b/src/auto-ocd.py
@@ -13,8 +13,9 @@ def rmDir(path):
         pass
 
 def clrDir(path):
-    rmDir(path)
-    os.makedirs(path)
+    if os.path.exists(path):
+        shutil.rmtree(path)  
+    os.makedirs(path)  
 
 if __name__ == "__main__": 
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
os.removeddirs() only removes empty parent dirs so if a path has files or subdirectories it will fail. shutil.rmtree() is better